### PR TITLE
Rename some options

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ See the [example](./index.html) for details
 | `technicalCues`      | `technical-cues`      |           | `Boolean`   | false                    | Display information such as languages or datatypes                 |
 | `compactMode`        | `compact-mode`        |           | `Boolean`   | false                    | Group repeated properties or values for a compact visualization    |
 | `preferredLanguages` | `preferred-languages` |           | `Array`     | ['en', 'fr', 'de', 'it'] | A list of the languages to show in the labels, ordered by priority |
-| `embedNamed`         | `embed-named`         |           | `Boolean`   | false                    | Recursively embeds any named entity positioned as an object        |
+| `embedNamedNodes`    | `embed-named-nodes`   |           | `Boolean`   | false                    | Recursively embeds any named entity positioned as an object        |
 | `maxLevel`           | `max-level`           |           | `Number`    | 3                        | The maximum depth of the trees                                     |
 | `namedGraphs`        | `named-graphs`        |           | `Boolean`   | false                    | Display stats about named graphs and counts                        |
 | `metadata`           | `metadata`            |           | `Object`    | undefined                | Additional values to display in the section `metadata`             |

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
 <rdf-entity id="demo"
             named-graphs
             compact-mode
-            embed-named
+            embed-named-nodes
             !embed-blank-nodes
             debug></rdf-entity>
 </body>

--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
             named-graphs
             compact-mode
             embed-named
-            !embed-blanks
+            !embed-blank-nodes
             debug></rdf-entity>
 </body>
 </html>

--- a/src/builder/entityBuilder.js
+++ b/src/builder/entityBuilder.js
@@ -25,7 +25,7 @@ function shouldEmbed (options, context) {
     if (term.termType === 'NamedNode' && !options.embedNamed) {
       return false
     }
-    if (term.termType === 'BlankNode' && !options.embedBlanks) {
+    if (term.termType === 'BlankNode' && !options.embedBlankNodes) {
       return false
     }
     return !(options.maxLevel && (context.level >= options.maxLevel))
@@ -105,7 +105,7 @@ function createEntityWithContext (cf, options, context) {
     groupPropertiesByValue: true,
     embedLists: true,
     embedNamed: false,
-    embedBlanks: true,
+    embedBlankNodes: true,
     maxLevel: undefined,
     preferredLanguages: ['en'],
     renderAs: (cf, options, context) => {

--- a/src/builder/entityBuilder.js
+++ b/src/builder/entityBuilder.js
@@ -22,7 +22,7 @@ function canEmbed (options, context) {
 
 function shouldEmbed (options, context) {
   return term => {
-    if (term.termType === 'NamedNode' && !options.embedNamed) {
+    if (term.termType === 'NamedNode' && !options.embedNamedNodes) {
       return false
     }
     if (term.termType === 'BlankNode' && !options.embedBlankNodes) {
@@ -104,7 +104,7 @@ function createEntityWithContext (cf, options, context) {
     groupValuesByProperty: true,
     groupPropertiesByValue: true,
     embedLists: true,
-    embedNamed: false,
+    embedNamedNodes: false,
     embedBlankNodes: true,
     maxLevel: undefined,
     preferredLanguages: ['en'],

--- a/src/components/Entity.js
+++ b/src/components/Entity.js
@@ -48,8 +48,8 @@ function TermWithCues (entity, options, context, renderedAsRoot) {
     spans.push(html`<span class="datatype">${entity.label.datatype.vocab}:${entity.label.datatype.string}</span>`)
   }
 
-  if (options?.highLightLanguage && entity.label.language) {
-    const isHighLight = entity.label.language === options.highLightLanguage
+  if (options?.highlightLanguage && entity.label.language) {
+    const isHighLight = entity.label.language === options.highlightLanguage
     return isHighLight
       ? html`
         <div>${spans}</div>`

--- a/src/options.js
+++ b/src/options.js
@@ -9,13 +9,13 @@ function boolean (value, defaultValue) {
 function getBuilderOptions (webComponent) {
   const preferredLanguages = webComponent.preferredLanguages ??
     ['en', 'fr', 'de', 'it']
-  const highLightLanguage = preferredLanguages.length > 0
+  const highlightLanguage = preferredLanguages.length > 0
     ? preferredLanguages[0]
     : undefined
   return {
     technicalCues: boolean(webComponent.technicalCues, false),
     preferredLanguages,
-    highLightLanguage,
+    highlightLanguage,
     embedLists: true,
     embedNamed: boolean(webComponent.embedNamed, false),
     embedBlankNodes: boolean(webComponent.embedBlankNodes, false),

--- a/src/options.js
+++ b/src/options.js
@@ -17,7 +17,7 @@ function getBuilderOptions (webComponent) {
     preferredLanguages,
     highlightLanguage,
     embedLists: true,
-    embedNamed: boolean(webComponent.embedNamed, false),
+    embedNamedNodes: boolean(webComponent.embedNamedNodes, false),
     embedBlankNodes: boolean(webComponent.embedBlankNodes, false),
     maxLevel: webComponent.maxLevel ?? 3,
     metadata: webComponent.metadata,

--- a/src/options.js
+++ b/src/options.js
@@ -18,7 +18,7 @@ function getBuilderOptions (webComponent) {
     highLightLanguage,
     embedLists: true,
     embedNamed: boolean(webComponent.embedNamed, false),
-    embedBlanks: boolean(webComponent.embedBlanks, false),
+    embedBlankNodes: boolean(webComponent.embedBlankNodes, false),
     maxLevel: webComponent.maxLevel ?? 3,
     metadata: webComponent.metadata,
     debug: boolean(webComponent.debug, false),

--- a/src/rdf-entity.js
+++ b/src/rdf-entity.js
@@ -147,7 +147,7 @@ export class RdfEntity extends LitElement {
       technicalCues: { type: Boolean, attribute: 'technical-cues', required: false },
       compactMode: { type: Boolean, attribute: 'compact-mode', required: false },
       preferredLanguages: { type: Array, attribute: 'preferred-languages', required: false },
-      embedNamed: { type: Boolean, attribute: 'embed-named', required: false },
+      embedNamedNodes: { type: Boolean, attribute: 'embed-named-nodes', required: false },
       embedBlankNodes: { type: Boolean, attribute: 'embed-blank-nodes', required: false },
 
       maxLevel: { type: Number, attribute: 'max-level', required: false },

--- a/src/rdf-entity.js
+++ b/src/rdf-entity.js
@@ -148,7 +148,7 @@ export class RdfEntity extends LitElement {
       compactMode: { type: Boolean, attribute: 'compact-mode', required: false },
       preferredLanguages: { type: Array, attribute: 'preferred-languages', required: false },
       embedNamed: { type: Boolean, attribute: 'embed-named', required: false },
-      embedBlanks: { type: Boolean, attribute: 'embed-blanks', required: false },
+      embedBlankNodes: { type: Boolean, attribute: 'embed-blank-nodes', required: false },
 
       maxLevel: { type: Number, attribute: 'max-level', required: false },
       namedGraphs: { type: Boolean, attribute: 'named-graphs', required: false },

--- a/test/entityBuilder.test.js
+++ b/test/entityBuilder.test.js
@@ -268,7 +268,7 @@ describe('ignore property', () => {
 
       const options = {
         embedNamed: true,
-        embedBlanks: true,
+        embedBlankNodes: true,
         ignoreProperties: rdf.termSet(
           [rdf.namedNode('http://www.w3.org/2000/01/rdf-schema#label')])
       }
@@ -291,7 +291,7 @@ describe('no grouping by value or property', () => {
         groupValuesByProperty: false,
         groupPropertiesByValue: false,
         embedNamed: true,
-        embedBlanks: true
+        embedBlankNodes: true
       }
 
       const result = createEntity(cf, options)

--- a/test/entityBuilder.test.js
+++ b/test/entityBuilder.test.js
@@ -267,7 +267,7 @@ describe('ignore property', () => {
       const cf = toClownface(turtle, term)
 
       const options = {
-        embedNamed: true,
+        embedNamedNodes: true,
         embedBlankNodes: true,
         ignoreProperties: rdf.termSet(
           [rdf.namedNode('http://www.w3.org/2000/01/rdf-schema#label')])
@@ -290,7 +290,7 @@ describe('no grouping by value or property', () => {
       const options = {
         groupValuesByProperty: false,
         groupPropertiesByValue: false,
-        embedNamed: true,
+        embedNamedNodes: true,
         embedBlankNodes: true
       }
 
@@ -313,7 +313,7 @@ it('do not repeat with compactMode false', function () {
 
   const options = {
     embedLists: true,
-    embedNamed: true,
+    embedNamedNodes: true,
     groupValuesByProperty: true,
     groupPropertiesByValue: true,
     externalLabels: rdf.clownface({ dataset: rdf.dataset() }),
@@ -336,7 +336,7 @@ it('do not repeat with compactMode true', function () {
 
   const options = {
     embedLists: false,
-    embedNamed: true,
+    embedNamedNodes: true,
     groupValuesByProperty: false,
     groupPropertiesByValue: false,
     externalLabels: rdf.clownface({ dataset: rdf.dataset() }),


### PR DESCRIPTION
This PR is here to rename the following options:
- `embedBlanks` to `embedBlankNodes`
- `highLightLanguage` to `highlightLanguage`
- `embedNamed` to `embedNamedNodes`

This will make it more consistent and more understandable.